### PR TITLE
Use urljoin to properly join base URL and relative paths

### DIFF
--- a/unwebpack_sourcemap.py
+++ b/unwebpack_sourcemap.py
@@ -16,6 +16,7 @@ import re
 import string
 import sys
 from urllib.parse import urlparse
+from urllib.parse import urljoin
 from unicodedata import normalize
 
 import requests
@@ -120,14 +121,7 @@ class SourceMapExtractor(object):
 
         for script in soup:
             source = script['src']
-            parsed_uri = urlparse(source)
-            next_target_uri = ""
-            if parsed_uri.scheme != '':
-                next_target_uri = source
-            else:
-                current_uri = urlparse(final_uri)
-                built_uri = current_uri.scheme + "://" + current_uri.netloc + source
-                next_target_uri = built_uri
+            next_target_uri = urljoin(final_uri, source)
 
             js_data, last_target_uri = self._get_remote_data(next_target_uri)
             # get last line of file
@@ -136,18 +130,9 @@ class SourceMapExtractor(object):
             matches = re.search(regex, last_line)
             if matches:
                 asset = matches.groups(0)[0].strip()
-                asset_target = urlparse(asset)
-                if asset_target.scheme != '':
-                    print("Detected sourcemap at remote location %s" % asset)
-                    remote_sourcemaps.append(asset)
-                else:
-                    current_uri = urlparse(last_target_uri)
-                    asset_uri = current_uri.scheme + '://' + \
-                        current_uri.netloc + \
-                        os.path.dirname(current_uri.path) + \
-                        '/' + asset
-                    print("Detected sourcemap at remote location %s" % asset_uri)
-                    remote_sourcemaps.append(asset_uri)
+                asset_uri = urljoin(last_target_uri, asset)
+                print("Detected sourcemap at remote location %s" % asset_uri)
+                remote_sourcemaps.append(asset_uri)
 
         return remote_sourcemaps
 


### PR DESCRIPTION
This PR fixes the source map detection functionality.

Currently, when relative paths are joined, the URL might contain too many slashes and some web-servers might reject the requests.
Example:
```bash
$ unwebpack-sourcemap -d --make-directory https://target.com output
Detecting sourcemaps in HTML at https://target.com/
Detected sourcemap at remote location https://target.com///js.ac728a64.map
WARNING: Got status code 403 for URI https://target.com///js.ac728a64.map
WARNING: Could not retrieve sourcemap from URI https://target.com///js.ac728a64.map
```
Using `urljoin` fixes the issue.